### PR TITLE
[fix]: sigsegv mbedtls libevent related

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/**
+build/**
+

--- a/include/pegasocks/ssl.h
+++ b/include/pegasocks/ssl.h
@@ -3,13 +3,25 @@
 
 #include "config.h"
 
-#ifndef USE_MBEDTLS
+#ifdef USE_MBEDTLS
+#include <mbedtls/ssl.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#else
 #include <event2/bufferevent_ssl.h>
 #endif
 
-struct pgs_ssl_ctx_s;
+typedef struct pgs_ssl_ctx_s {
+	mbedtls_ssl_config conf;
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+	mbedtls_x509_crt cacert;
+} pgs_ssl_ctx_t;
 
-typedef struct pgs_ssl_ctx_s pgs_ssl_ctx_t;
+typedef struct {
+	mbedtls_ssl_context *ssl;
+	void *cb_ctx;
+} pgs_bev_ctx_t;
 
 pgs_ssl_ctx_t *pgs_ssl_ctx_new(pgs_config_t *config);
 void pgs_ssl_ctx_free(pgs_ssl_ctx_t *ctx);

--- a/src/crypto/mbedtls.c
+++ b/src/crypto/mbedtls.c
@@ -220,7 +220,6 @@ void sha1(const uint8_t *input, uint64_t input_len, uint8_t *res)
 
 #endif
 
-
 void hmac_md5(const uint8_t *key, uint64_t key_len, const uint8_t *data,
 	      uint64_t data_len, uint8_t *out, uint64_t *out_len)
 {
@@ -497,16 +496,19 @@ static bool pgs_cryptor_encrypt_gcm(pgs_cryptor_t *ptr,
 	}
 
 	// Encrypt the plaintext
-	if (mbedtls_gcm_update(ptr->ctx, plaintext, plaintext_len, ciphertext, plaintext_len, &out_len)) {
+	if (mbedtls_gcm_update(ptr->ctx, plaintext, plaintext_len, ciphertext,
+			       plaintext_len, &out_len)) {
 		return false;
 	}
 
 	// Finalize the operation and generate the tag
-	if (mbedtls_gcm_finish(ptr->ctx, NULL, 0, &out_len, tag, ptr->tag_len)) {
+	if (mbedtls_gcm_finish(ptr->ctx, NULL, 0, &out_len, tag,
+			       ptr->tag_len)) {
 		return false;
 	}
 
-	*ciphertext_len = plaintext_len; // The ciphertext length matches the plaintext length
+	*ciphertext_len =
+		plaintext_len; // The ciphertext length matches the plaintext length
 	return true;
 }
 
@@ -529,16 +531,19 @@ static bool pgs_cryptor_decrypt_gcm(pgs_cryptor_t *ptr,
 	}
 
 	// Decrypt the ciphertext
-	if (mbedtls_gcm_update(ptr->ctx, ciphertext, ciphertext_len, plaintext, ciphertext_len, &out_len)) {
+	if (mbedtls_gcm_update(ptr->ctx, ciphertext, ciphertext_len, plaintext,
+			       ciphertext_len, &out_len)) {
 		return false;
 	}
 
 	// Finalize the operation
-	if (mbedtls_gcm_finish(ptr->ctx, NULL, 0, &out_len, (unsigned char *)tag, ptr->tag_len)) {
+	if (mbedtls_gcm_finish(ptr->ctx, NULL, 0, &out_len,
+			       (unsigned char *)tag, ptr->tag_len)) {
 		return false;
 	}
 
-	*plaintext_len = ciphertext_len; // The plaintext length matches the ciphertext length
+	*plaintext_len =
+		ciphertext_len; // The plaintext length matches the ciphertext length
 	return true;
 }
 

--- a/src/server/metrics.c
+++ b/src/server/metrics.c
@@ -7,6 +7,10 @@
 #include "applet.h"
 #endif
 
+#ifdef USE_MBEDTLS
+#include "ssl.h"
+#endif
+
 const unsigned char g204_cmd[] = { 0x05, 0x01, 0x00, 0x03, 0x0d, 0x77, 0x77,
 				   0x77, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
 				   0x65, 0x2e, 0x63, 0x6e, 0x00, 0x50 };
@@ -48,7 +52,8 @@ static double elapse(struct timeval start_at)
 static void on_trojan_g204_event(struct bufferevent *bev, short events,
 				 void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	if (events & BEV_EVENT_TIMEOUT) {
 		pgs_logger_error(mctx->logger, "(%s)%s:%d g204 timeout",
 				 mctx->config->server_type,
@@ -68,7 +73,8 @@ static void on_trojan_g204_event(struct bufferevent *bev, short events,
 
 static void on_trojan_g204_read(struct bufferevent *bev, void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	const pgs_config_extra_trojan_t *tconfig = mctx->config->extra;
 	if (tconfig->websocket.enabled) {
 		on_trojan_ws_g204_read(bev, ctx);
@@ -80,7 +86,8 @@ static void on_trojan_g204_read(struct bufferevent *bev, void *ctx)
 static void on_v2ray_g204_event(struct bufferevent *bev, short events,
 				void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	if (events & BEV_EVENT_TIMEOUT) {
 		pgs_logger_error(mctx->logger, "v2ray g204 timeout");
 		if (mctx)
@@ -97,7 +104,8 @@ static void on_v2ray_g204_event(struct bufferevent *bev, short events,
 
 static void on_v2ray_g204_read(struct bufferevent *bev, void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	const pgs_config_extra_v2ray_t *vconfig = mctx->config->extra;
 	if (vconfig->websocket.enabled) {
 		on_v2ray_ws_g204_read(bev, ctx);
@@ -182,7 +190,8 @@ error:
 
 static void on_ws_g204_event(struct bufferevent *bev, short events, void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	if (events & BEV_EVENT_CONNECTED)
 		do_ws_remote_request(bev, ctx);
 	if (events & BEV_EVENT_ERROR)
@@ -197,7 +206,8 @@ static void on_ws_g204_event(struct bufferevent *bev, short events, void *ctx)
 
 static void on_trojan_ws_g204_read(struct bufferevent *bev, void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	pgs_logger_debug(mctx->logger, "remote read triggered");
 	struct evbuffer *output = bufferevent_get_output(bev);
 	struct evbuffer *input = bufferevent_get_input(bev);
@@ -256,7 +266,8 @@ static void v2ray_ws_vmess_write_cb(struct evbuffer *writer, uint8_t *data,
 
 static void on_v2ray_ws_g204_read(struct bufferevent *bev, void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	struct evbuffer *output = bufferevent_get_output(bev);
 	struct evbuffer *input = bufferevent_get_input(bev);
 
@@ -300,7 +311,8 @@ static void on_v2ray_ws_g204_read(struct bufferevent *bev, void *ctx)
 static void on_trojan_gfw_g204_read(struct bufferevent *bev, void *ctx)
 {
 	// with data
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	double g204_time = elapse(mctx->start_at);
 	pgs_logger_debug(mctx->logger, "g204: %f", g204_time);
 	pgs_metrics_update(&mctx->sm->server_stats[mctx->server_idx],
@@ -311,7 +323,8 @@ static void on_trojan_gfw_g204_event(struct bufferevent *bev, short events,
 				     void *ctx)
 {
 	// connect time and error handling
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	if (events & BEV_EVENT_CONNECTED) {
 		// set connected
 		pgs_outbound_ctx_trojan_t *sctx = mctx->outbound->ctx;
@@ -343,7 +356,8 @@ static void on_trojan_gfw_g204_event(struct bufferevent *bev, short events,
 }
 static void on_v2ray_tcp_g204_read(struct bufferevent *bev, void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	double g204_time = elapse(mctx->start_at);
 	pgs_logger_debug(mctx->logger, "g204: %f", g204_time);
 	pgs_metrics_update(&mctx->sm->server_stats[mctx->server_idx],
@@ -354,7 +368,8 @@ static void on_v2ray_tcp_g204_read(struct bufferevent *bev, void *ctx)
 
 static void on_ss_g204_read(struct bufferevent *bev, void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	double g204_time = elapse(mctx->start_at);
 	pgs_logger_debug(mctx->logger, "g204: %f", g204_time);
 	pgs_metrics_update(&mctx->sm->server_stats[mctx->server_idx],
@@ -365,7 +380,8 @@ static void on_ss_g204_read(struct bufferevent *bev, void *ctx)
 
 static void on_ss_g204_event(struct bufferevent *bev, short events, void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	if (events & BEV_EVENT_TIMEOUT) {
 		pgs_logger_error(mctx->logger, "shadowsocks g204 timeout");
 		if (mctx)
@@ -403,7 +419,8 @@ static void on_ss_g204_event(struct bufferevent *bev, short events, void *ctx)
 static void on_v2ray_tcp_g204_event(struct bufferevent *bev, short events,
 				    void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	if (events & BEV_EVENT_CONNECTED) {
 		// set connected
 		pgs_outbound_ctx_v2ray_t *sctx = mctx->outbound->ctx;
@@ -433,7 +450,8 @@ static void on_v2ray_tcp_g204_event(struct bufferevent *bev, short events,
 
 static void do_ws_remote_request(struct bufferevent *bev, void *ctx)
 {
-	pgs_metrics_task_ctx_t *mctx = (pgs_metrics_task_ctx_t *)ctx;
+	pgs_bev_ctx_t *bev_ctx = ctx;
+	pgs_metrics_task_ctx_t *mctx = bev_ctx->cb_ctx;
 	const pgs_server_config_t *config = mctx->outbound->config;
 
 	const pgs_config_ws_t *ws_config = config->extra;

--- a/src/session/inbound.c
+++ b/src/session/inbound.c
@@ -2,13 +2,13 @@
 #include "session/session.h"
 #include "session/udp.h"
 
+#include <event2/buffer.h>
 #include <event2/bufferevent.h>
 #include <event2/event.h>
-#include <event2/buffer.h>
 
-#include <unistd.h>
 #include <fcntl.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 typedef struct pgs_udp_read_param_s {
 	bool proxy;
@@ -31,7 +31,7 @@ static void on_local_read(struct bufferevent *bev, void *ctx);
 
 /*
  * udp
-  */
+ */
 static int start_udp_server(const pgs_server_config_t *sconfig,
 			    pgs_session_t *session, int *port);
 static void on_udp_read(int fd, short event, void *ctx);
@@ -148,7 +148,7 @@ void on_trojan_local_read(struct bufferevent *bev, void *ctx)
 	pgs_config_extra_trojan_t *tsconf =
 		(pgs_config_extra_trojan_t *)config->extra;
 	if (tsconf->websocket.enabled) {
-		//ws
+		// ws
 		uint64_t head_len = tctx->head_len;
 		uint64_t ws_len = len;
 		if (head_len > 0) {
@@ -207,9 +207,9 @@ void on_ss_local_read(struct bufferevent *bev, void *ctx)
 		return;
 
 	/*
-		Payload length is a 2-byte big-endian unsigned integer capped at 0x3FFF. 
-		The higher two bits are reserved and must be set to zero. 
-		Payload is therefore limited to 16*1024 - 1 bytes.
+	Payload length is a 2-byte big-endian unsigned integer capped at
+	0x3FFF. The higher two bits are reserved and must be set to zero. Payload
+	is therefore limited to 16*1024 - 1 bytes.
 	*/
 	if (len > 0x3FFF) {
 		len = 0x3FFF;
@@ -670,7 +670,8 @@ static void do_udp_read(pgs_udp_read_param_t *param)
 		if (!param->session->outbound->ready) {
 			param->session->inbound->rbuf_pos = param->len;
 			// should be called once ready
-			// notice, this will lost data if client send more than one udp packet before the remote is ready
+			// notice, this will lost data if client send more than one udp packet
+			// before the remote is ready
 			return;
 		}
 		if (IS_TROJAN_SERVER(param->config->server_type)) {
@@ -740,7 +741,7 @@ static void udp_dns_cb(int result, char type, int count, int ttl, void *addrs,
 				(int)(uint8_t)((ip >> 24) & 0xff),
 				(int)(uint8_t)((ip >> 16) & 0xff),
 				(int)(uint8_t)((ip >> 8) & 0xff),
-				(int)(uint8_t)((ip)&0xff));
+				(int)(uint8_t)((ip) & 0xff));
 
 			pgs_session_debug(ctx->session, "%s: %s", ctx->dest,
 					  dest);

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -1,15 +1,15 @@
+#include "session/session.h"
 #include "codec/codec.h"
 #include "crypto.h"
 #include "defs.h"
-#include "session/session.h"
-#include "server/manager.h"
 #include "log.h"
-#include "session/udp.h"
+#include "server/manager.h"
 #include "session/session.h"
+#include "session/udp.h"
 
-#include <unistd.h>
 #include <assert.h>
 #include <ctype.h>
+#include <unistd.h>
 
 #include <fcntl.h>
 
@@ -18,7 +18,7 @@
  *
  * @param fd the local socket fd
  * @param local_address the local_server object
- *  which contains logger, base, etc..
+ *	which contains logger, base, etc..
  * @return a pointer of new session
  */
 pgs_session_t *pgs_session_new(int fd, pgs_local_server_t *local_server)
@@ -72,7 +72,8 @@ void pgs_session_free(pgs_session_t *session)
 			}
 			pgs_session_info(
 				session,
-				"%sconnection to %s:%d closed, start: %s, end: %s, send: %d, recv: %d",
+				"%sconnection to %s:%d closed, start: %s, end: %s, "
+				"send: %d, recv: %d",
 				prefix, session->outbound->dest,
 				session->outbound->port, tm_start_str,
 				tm_end_str, session->metrics->send,

--- a/src/ssl/mbedtls.c
+++ b/src/ssl/mbedtls.c
@@ -8,12 +8,6 @@
 
 #include <stdlib.h>
 
-struct pgs_ssl_ctx_s {
-	mbedtls_ssl_config conf;
-	mbedtls_entropy_context entropy;
-	mbedtls_ctr_drbg_context ctr_drbg;
-	mbedtls_x509_crt cacert;
-};
 
 pgs_ssl_ctx_t *pgs_ssl_ctx_new(pgs_config_t *config)
 {
@@ -114,9 +108,13 @@ int pgs_session_outbound_ssl_bev_init(struct bufferevent **bev, int fd,
 		free(ssl);
 		return -1;
 	}
+	
+	
+	pgs_bev_ctx_t *bev_ctx = malloc(sizeof(pgs_bev_ctx_t));
+	bev_ctx->ssl = ssl;
+	bev_ctx->cb_ctx = NULL;
 
-	// Set callbacks and associate mbedTLS SSL context as the cbarg
-	bufferevent_setcb(*bev, NULL, NULL, NULL, ssl);
+	bufferevent_setcb(*bev, NULL, NULL, NULL, bev_ctx);
 
 	return 0;
 }


### PR DESCRIPTION
очередная версия. 

с таким конфигом не виснет при подключении через socks

```
 "servers": [
  {
   "server_address": "yandex.ru",
   "server_type": "trojan",
   "server_port": 443,
   "password": "ee7fcd2d-8e71-1111-b333-4cae03f4ac55",
   "websocket": {
    "path": "/",
    "hostname": "yandex.ru"
   },
   "ssl": {
    "sni": "sni.my.net"
   }
  }
 ],
 "ping_interval": 120,
 "local_address": "192.168.1.1",
 "local_port": 1080,
 "log_level": 1
}

```